### PR TITLE
Crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: dbus
-version: 0.1.0
+version: 0.0.3
 
 authors:
   - Oleh Prypin <oleh@pryp.in>

--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ description: |
 
 license: MIT
 
-crystal: 0.28.0  # down to 0.22.0
+crystal: 1.0.0
 
 libraries:
   libdbus: ~> 1.10


### PR DESCRIPTION
Updates the shard.yml to define the Crystal version as 1.0.0. Makes this shard compatible as a dependency with Crystal 1.0.0+ projects.